### PR TITLE
Fix README code block and add HF token info

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,8 @@ A simple Streamlit app for uploading and viewing broker data from Excel.
 ```bash
 pip install -r requirements.txt
 streamlit run app.py
+```
+
+### Hugging Face Token
+
+This app requires a Hugging Face token to access the summarization model. Store your token in `.streamlit/secrets.toml` under the key `HF_TOKEN` or set it as an environment variable.


### PR DESCRIPTION
## Summary
- finish README code block with closing triple backticks
- add instructions for setting HF token in `.streamlit/secrets.toml` or as an environment variable

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68536eaeb4a4832d838fd7df5d5b8552